### PR TITLE
Add support for z.ai provider for claude code

### DIFF
--- a/internal/profiles/claude_code.go
+++ b/internal/profiles/claude_code.go
@@ -32,6 +32,7 @@ func (c *ClaudeCodeProfile) SupportedBackends() []Backend {
 		{Type: BackendAnthropic, DisplayName: "Anthropic API"},
 		{Type: BackendBedrock, DisplayName: "AWS Bedrock"},
 		{Type: BackendVertex, DisplayName: "Google Vertex"},
+		{Type: BackendZAI, DisplayName: "z.ai"},
 	}
 }
 
@@ -66,12 +67,19 @@ func (c *ClaudeCodeProfile) RequiredCompat(b Backend) []string {
 		return []string{"bedrock_model_invoke"}
 	case BackendVertex:
 		return []string{"google_raw_predict"}
+	case BackendZAI:
+		return []string{"anthropic_messages"}
 	default:
 		return nil
 	}
 }
 
 func (c *ClaudeCodeProfile) ProviderEnv(b Backend, providers []ProviderInfo) map[string]string {
+	// ZAI uses fixed model names set in Env; do not override them.
+	if b.Type == BackendZAI {
+		return nil
+	}
+
 	keys := c.RequiredCompat(b)
 
 	// Collect models from all providers compatible with the chosen backend.
@@ -112,6 +120,7 @@ func (c *ClaudeCodeProfile) ProviderEnv(b Backend, providers []ProviderInfo) map
 // may set when launching Claude Code, across all backends.
 var managedEnvVars = []string{
 	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_MODEL",
 	"ANTHROPIC_AUTH_TOKEN",
 	"ANTHROPIC_BEDROCK_BASE_URL",
 	"CLAUDE_CODE_USE_BEDROCK",
@@ -124,6 +133,8 @@ var managedEnvVars = []string{
 	"ANTHROPIC_DEFAULT_OPUS_MODEL",
 	"ANTHROPIC_DEFAULT_SONNET_MODEL",
 	"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	"API_TIMEOUT_MS",
+	"ANTHROPIC_API_KEY",
 }
 
 // Check validates that ~/.claude/settings.json does not set environment
@@ -193,6 +204,16 @@ func (c *ClaudeCodeProfile) Env(apertureHost string, b Backend) (map[string]stri
 			"CLAUDE_CODE_SKIP_VERTEX_AUTH": "1",
 			"ANTHROPIC_VERTEX_PROJECT_ID":  "_aperture_auto_vertex_project_id_",
 			"ANTHROPIC_VERTEX_BASE_URL":    apertureHost + "/v1",
+		}, nil
+	case BackendZAI:
+		return map[string]string{
+			"ANTHROPIC_BASE_URL":             apertureHost,
+			"ANTHROPIC_MODEL":                "glm-5.1",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL":   "glm-5.1",
+			"ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "glm-5-turbo",
+			"API_TIMEOUT_MS":                 "3000000",
+			"ANTHROPIC_API_KEY":              "-",
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported backend %q for Claude Code", b.Type)

--- a/internal/profiles/opencode.go
+++ b/internal/profiles/opencode.go
@@ -76,7 +76,7 @@ func (o *OpenCodeProfile) Env(apertureHost string, b Backend) (map[string]string
 	switch b.Type {
 	case BackendAnthropic:
 		return map[string]string{
-			"ANTHROPIC_BASE_URL":   apertureHost + "/bedrock",
+			"ANTHROPIC_BASE_URL":   apertureHost + "/v1",
 			"ANTHROPIC_AUTH_TOKEN": "-",
 		}, nil
 	case BackendBedrock:

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -16,6 +16,7 @@ const (
 	BackendVertex    BackendType = "vertex"
 	BackendGemini    BackendType = "gemini"
 	BackendOpenAI    BackendType = "openai"
+	BackendZAI       BackendType = "zai"
 )
 
 // Backend is a selectable upstream destination.

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -137,8 +137,8 @@ func TestLauncher_OpenCode_Env_Anthropic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Env returned error: %v", err)
 	}
-	if got := env["ANTHROPIC_BASE_URL"]; got != testHost+"/bedrock" {
-		t.Errorf("ANTHROPIC_BASE_URL = %q, want %q", got, testHost+"/bedrock")
+	if got := env["ANTHROPIC_BASE_URL"]; got != testHost+"/v1" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q, want %q", got, testHost+"/v1")
 	}
 }
 

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -82,6 +82,31 @@ func TestLauncher_ClaudeCode_Env_Vertex(t *testing.T) {
 	}
 }
 
+func TestLauncher_ClaudeCode_Env_ZAI(t *testing.T) {
+	p := &profiles.ClaudeCodeProfile{}
+	b := profiles.Backend{Type: profiles.BackendZAI, DisplayName: "z.ai"}
+
+	env, err := p.Env(testHost, b)
+	if err != nil {
+		t.Fatalf("Env returned error: %v", err)
+	}
+
+	want := map[string]string{
+		"ANTHROPIC_BASE_URL":             testHost,
+		"ANTHROPIC_MODEL":                "glm-5.1",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "glm-5.1",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "glm-5-turbo",
+		"API_TIMEOUT_MS":                 "3000000",
+		"ANTHROPIC_API_KEY":              "-",
+	}
+	for k, wantV := range want {
+		if got := env[k]; got != wantV {
+			t.Errorf("%s = %q, want %q", k, got, wantV)
+		}
+	}
+}
+
 func TestLauncher_GeminiCLI_Env_Vertex(t *testing.T) {
 	p := &profiles.GeminiCLIProfile{}
 	b := profiles.Backend{Type: profiles.BackendVertex, DisplayName: "Google Vertex"}


### PR DESCRIPTION
Add an option for z.ai support for claude code. The aperture config would look like: 

```jsonc

"zai_ant": {
	"baseurl": "https://api.z.ai/api/anthropic",
	"apikey":  "api-key-from-z.ai",
	"models": [
		"glm-5.1",
		"glm-5-turbo",
		"glm-4.7",
	],
	"compatibility": {
		"anthropic_messages": true,
		"openai_chat":        false,
	},
},

```