### PR TITLE
Make endpoint switching explicit and safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ This is useful on machines where installing Tailscale is not practical, where Ap
 
 To use bridge mode:
 
-1. Open `Settings`, then open `Bridges` and press `a` to add a bridge.
-2. Go back to `Settings`, then open `Aperture Endpoints` and press `a` to add an endpoint.
-3. Choose `Bridge`, select the bridge you created, then enter the Aperture URL.
-4. Select the bridged endpoint so it becomes active.
-5. Follow the Tailscale login prompt for the bridge.
-6. Launch an agent.
+1. Open `Settings`, then open `Aperture Endpoints` and press `a` to add an endpoint.
+2. Choose `Bridge`, then select an existing bridge or choose `Add Bridge`.
+3. Enter the Aperture URL and follow the Tailscale login prompt for the bridge.
+4. Aperture CLI verifies `/v1/models`, makes the endpoint active, and returns to the agent menu.
+
+If verification fails, the endpoint remains configured for retry or editing, and any previous working endpoint remains active. Select a configured endpoint from `Aperture Endpoints` to switch to it.
 
 ### Flags
 

--- a/internal/clients/registry.go
+++ b/internal/clients/registry.go
@@ -43,8 +43,9 @@ type Client interface {
 	Menu(g *config.Global) menu.MenuItem
 
 	// Replay attempts to re-launch the client using the last-used selection
-	// stored in g.LastLaunch. Returns nil if the state is stale (binary
-	// missing, provider gone from g.Providers, model no longer listed).
+	// stored in g.LastLaunch. The TUI only offers replay when the recorded
+	// endpoint is active. Returns nil if the state is stale (binary missing,
+	// provider gone from g.Providers, model no longer listed).
 	Replay(g *config.Global) tea.Cmd
 
 	// QuickSelectLabel is the display text for the [0] quick-select row

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -73,15 +73,20 @@ func (g *Global) ActiveEndpoint() Endpoint {
 // (adding it if missing), updates ApertureHost to the endpoint URL, and
 // persists. Bridge activation later rewrites ApertureHost to localhost.
 func (g *Global) SetActiveEndpoint(ep Endpoint) error {
-	g.ApertureHost = ep.URL
 	eps := []Endpoint{ep}
-	for _, ep := range g.Settings.Endpoints {
-		if !sameEndpoint(ep, eps[0]) {
-			eps = append(eps, ep)
+	for _, existing := range g.Settings.Endpoints {
+		if !sameEndpoint(existing, ep) {
+			eps = append(eps, existing)
 		}
 	}
-	g.Settings.Endpoints = eps
-	return SaveSettings(g.Settings)
+	next := g.Settings
+	next.Endpoints = eps
+	if err := SaveSettings(next); err != nil {
+		return err
+	}
+	g.Settings = next
+	g.ApertureHost = ep.URL
+	return nil
 }
 
 // SetApertureHost rotates the direct URL to the front of the endpoint list
@@ -98,8 +103,54 @@ func (g *Global) UpsertEndpoint(ep Endpoint) error {
 			return nil
 		}
 	}
-	g.Settings.Endpoints = append(g.Settings.Endpoints, ep)
-	return SaveSettings(g.Settings)
+	next := g.Settings
+	next.Endpoints = append(append([]Endpoint(nil), g.Settings.Endpoints...), ep)
+	if err := SaveSettings(next); err != nil {
+		return err
+	}
+	g.Settings = next
+	return nil
+}
+
+// ReplaceEndpoint replaces old with next in place and persists the result.
+// It does not change which endpoint is active unless old is already active.
+func (g *Global) ReplaceEndpoint(old, next Endpoint) error {
+	eps := append([]Endpoint(nil), g.Settings.Endpoints...)
+	oldIdx := -1
+	for i, existing := range eps {
+		if !sameEndpoint(existing, old) {
+			continue
+		}
+		oldIdx = i
+		break
+	}
+	if oldIdx < 0 {
+		return fmt.Errorf("endpoint %s is not configured", old.URL)
+	}
+	eps[oldIdx] = next
+	deduped := eps[:0]
+	for _, ep := range eps {
+		duplicate := false
+		for _, existing := range deduped {
+			if sameEndpoint(existing, ep) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			deduped = append(deduped, ep)
+		}
+	}
+	updated := g.Settings
+	updated.Endpoints = deduped
+	if err := SaveSettings(updated); err != nil {
+		return err
+	}
+	g.Settings = updated
+	if oldIdx == 0 {
+		g.ApertureHost = next.URL
+	}
+	return nil
 }
 
 // RemoveEndpoint deletes the endpoint at idx and persists. The active endpoint
@@ -112,11 +163,16 @@ func (g *Global) RemoveEndpoint(idx int) error {
 	eps := make([]Endpoint, 0, len(g.Settings.Endpoints)-1)
 	eps = append(eps, g.Settings.Endpoints[:idx]...)
 	eps = append(eps, g.Settings.Endpoints[idx+1:]...)
-	g.Settings.Endpoints = eps
-	if len(eps) > 0 {
+	next := g.Settings
+	next.Endpoints = eps
+	if err := SaveSettings(next); err != nil {
+		return err
+	}
+	g.Settings = next
+	if idx == 0 && len(eps) > 0 {
 		g.ApertureHost = eps[0].URL
 	}
-	return SaveSettings(g.Settings)
+	return nil
 }
 
 // AddBridge creates, saves, and returns a bridge with a generated stable ID.
@@ -130,10 +186,12 @@ func (g *Global) AddBridge(name string) (Bridge, error) {
 		return Bridge{}, err
 	}
 	p := Bridge{ID: id, Name: name}
-	g.Settings.Bridges = append(g.Settings.Bridges, p)
-	if err := SaveSettings(g.Settings); err != nil {
+	next := g.Settings
+	next.Bridges = append(append([]Bridge(nil), g.Settings.Bridges...), p)
+	if err := SaveSettings(next); err != nil {
 		return Bridge{}, err
 	}
+	g.Settings = next
 	return p, nil
 }
 
@@ -148,8 +206,14 @@ func (g *Global) RemoveBridge(id string) error {
 		if p.ID != id {
 			continue
 		}
-		g.Settings.Bridges = append(g.Settings.Bridges[:i], g.Settings.Bridges[i+1:]...)
-		return SaveSettings(g.Settings)
+		next := g.Settings
+		next.Bridges = append([]Bridge(nil), g.Settings.Bridges[:i]...)
+		next.Bridges = append(next.Bridges, g.Settings.Bridges[i+1:]...)
+		if err := SaveSettings(next); err != nil {
+			return err
+		}
+		g.Settings = next
+		return nil
 	}
 	return nil
 }
@@ -166,6 +230,9 @@ func (g *Global) Bridge(id string) (Bridge, bool) {
 
 // RecordLaunch stores the launch record to disk and updates the in-memory copy.
 func (g *Global) RecordLaunch(s LaunchState) error {
+	ep := g.ActiveEndpoint()
+	s.LastEndpointURL = ep.URL
+	s.LastBridgeID = ep.BridgeID
 	g.LastLaunch = s
 	return SaveState(s)
 }

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -6,13 +6,15 @@ import (
 	"path/filepath"
 )
 
-// LaunchState records the last-used client/backend/provider/model so the TUI
-// can offer a one-key quick re-launch on startup.
+// LaunchState records the last-used client, endpoint, provider, backend, and
+// model so the TUI can offer a one-key quick re-launch on startup.
 type LaunchState struct {
 	LastClientName  string `json:"lastClientName,omitempty"`
 	LastBackendType string `json:"lastBackendType,omitempty"`
 	LastProviderID  string `json:"lastProviderId,omitempty"`
 	LastModel       string `json:"lastModel,omitempty"`
+	LastEndpointURL string `json:"lastEndpointUrl,omitempty"`
+	LastBridgeID    string `json:"lastBridgeId,omitempty"`
 }
 
 // statePath returns the path to the launcher state JSON file.

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -22,6 +22,8 @@ func TestLaunchState_RoundTrip(t *testing.T) {
 		LastBackendType: "bedrock",
 		LastProviderID:  "anthropic-via-aperture",
 		LastModel:       "anthropic-via-aperture/claude-sonnet",
+		LastEndpointURL: "http://aperture.example.com",
+		LastBridgeID:    "bridge-abcdef",
 	}
 	if err := config.SaveState(want); err != nil {
 		t.Fatalf("SaveState: %v", err)
@@ -71,6 +73,22 @@ func TestLaunchState_LegacyMigration(t *testing.T) {
 	}
 	if got.LastProviderID != "anthropic-via-aperture" {
 		t.Errorf("LastProviderID = %q", got.LastProviderID)
+	}
+}
+
+func TestGlobal_RecordLaunchBindsActiveEndpoint(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	g := &config.Global{Settings: config.Settings{Endpoints: []config.Endpoint{
+		{URL: "http://aperture.example.com", BridgeID: "bridge-abcdef"},
+	}}}
+	if err := g.RecordLaunch(config.LaunchState{LastClientName: "Claude Code"}); err != nil {
+		t.Fatal(err)
+	}
+	if g.LastLaunch.LastEndpointURL != "http://aperture.example.com" || g.LastLaunch.LastBridgeID != "bridge-abcdef" {
+		t.Fatalf("recorded launch endpoint = %q via %q", g.LastLaunch.LastEndpointURL, g.LastLaunch.LastBridgeID)
 	}
 }
 
@@ -201,6 +219,42 @@ func TestGlobal_SetActiveEndpoint_DistinguishesBridge(t *testing.T) {
 	}
 	if len(g.Settings.Endpoints) != 2 {
 		t.Errorf("endpoints len = %d, want 2", len(g.Settings.Endpoints))
+	}
+}
+
+func TestGlobal_RemoveInactiveEndpointPreservesRuntimeHost(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	g := &config.Global{
+		ApertureHost: "http://127.0.0.1:12345",
+		Settings: config.Settings{Endpoints: []config.Endpoint{
+			{URL: "http://active", BridgeID: "bridge-abcdef"},
+			{URL: "http://candidate", BridgeID: "bridge-fedcba"},
+		}},
+	}
+	if err := g.RemoveEndpoint(1); err != nil {
+		t.Fatal(err)
+	}
+	if g.ApertureHost != "http://127.0.0.1:12345" {
+		t.Fatalf("removing inactive endpoint changed runtime host to %q", g.ApertureHost)
+	}
+}
+
+func TestGlobal_ReplaceEndpointDeduplicates(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	active := config.Endpoint{URL: "http://active"}
+	candidate := config.Endpoint{URL: "http://candidate"}
+	g := &config.Global{Settings: config.Settings{Endpoints: []config.Endpoint{active, candidate}}}
+	if err := g.ReplaceEndpoint(candidate, active); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Settings.Endpoints) != 1 || g.Settings.Endpoints[0] != active {
+		t.Fatalf("endpoints = %+v, want one active endpoint", g.Settings.Endpoints)
 	}
 }
 

--- a/internal/tui/menus.go
+++ b/internal/tui/menus.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -82,19 +83,72 @@ func (m *model) rootMenu() *menu.Menu {
 }
 
 // quickSelect returns the tea.Cmd that replays the last successful launch
-// and the human-readable label to render next to [0]. Returns nil if no
-// client claims the last launch or its state is stale.
+// and the human-readable label to render next to [0]. Returns nil if the
+// recorded endpoint is not active or the client selection is stale.
 func (m *model) quickSelect() (tea.Cmd, string) {
 	if m.g.LastLaunch.LastClientName == "" {
 		return nil, ""
 	}
 	for _, c := range registeredClients(m.g) {
-		cmd := c.Replay(m.g)
-		if cmd != nil {
-			return cmd, c.QuickSelectLabel(m.g)
+		if c.Name() != m.g.LastLaunch.LastClientName {
+			continue
 		}
+		saved, hasSavedEndpoint := m.lastLaunchEndpoint()
+		// Legacy launch state did not identify its endpoint. Do not silently
+		// replay it against whichever endpoint happens to be active now.
+		if !hasSavedEndpoint || !m.endpointConfigured(saved) {
+			return nil, ""
+		}
+		if !sameEndpoint(saved, m.g.ActiveEndpoint()) {
+			return nil, ""
+		}
+		if cmd := c.Replay(m.g); cmd != nil {
+			label := c.QuickSelectLabel(m.g)
+			label += " @ " + m.endpointLabel(saved)
+			return cmd, label
+		}
+		return nil, ""
 	}
 	return nil, ""
+}
+
+func (m *model) lastLaunchEndpoint() (config.Endpoint, bool) {
+	if m.g.LastLaunch.LastEndpointURL == "" {
+		return config.Endpoint{}, false
+	}
+	return config.Endpoint{
+		URL:      m.g.LastLaunch.LastEndpointURL,
+		BridgeID: m.g.LastLaunch.LastBridgeID,
+	}, true
+}
+
+func (m *model) endpointConfigured(want config.Endpoint) bool {
+	for _, ep := range m.g.Settings.Endpoints {
+		if sameEndpoint(ep, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameEndpoint(a, b config.Endpoint) bool {
+	return a.URL == b.URL && a.BridgeID == b.BridgeID
+}
+
+func endpointFromInput(value, bridgeID string) (config.Endpoint, error) {
+	value = strings.TrimSpace(value)
+	if !strings.Contains(value, "://") {
+		value = "http://" + value
+	}
+	u, err := url.ParseRequestURI(value)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return config.Endpoint{}, fmt.Errorf("endpoint URL must be an absolute http or https URL")
+	}
+	return config.Endpoint{URL: strings.TrimRight(value, "/"), BridgeID: bridgeID}, nil
+}
+
+func simpleErrorCmd(err error) tea.Cmd {
+	return func() tea.Msg { return menu.SimpleDoneMsg{Err: err} }
 }
 
 // settingsMenu is the top-level Settings page: endpoints, uninstall, YOLO toggle.
@@ -183,7 +237,7 @@ func (m *model) bridgesMenu() *menu.Menu {
 }
 
 // endpointsMenu lists configured endpoints with add/delete affordances.
-// Selecting an entry rotates it to the front and re-runs preflight.
+// Selecting an entry runs preflight and promotes it only after success.
 func (m *model) endpointsMenu() *menu.Menu {
 	items := make([]menu.MenuItem, 0, len(m.g.Settings.Endpoints)+3)
 	for i, ep := range m.g.Settings.Endpoints {
@@ -195,9 +249,6 @@ func (m *model) endpointsMenu() *menu.Menu {
 		items = append(items, menu.MenuItem{
 			Label: label,
 			Action: func() menu.Result {
-				if err := m.g.SetActiveEndpoint(ep); err != nil {
-					return errResult(err.Error())
-				}
 				return menu.Result{Cmd: m.activateEndpointCmd(ep)}
 			},
 		})
@@ -219,7 +270,18 @@ func (m *model) endpointsMenu() *menu.Menu {
 			if idx < 0 || idx >= len(m.g.Settings.Endpoints) || len(m.g.Settings.Endpoints) <= 1 {
 				return menu.Result{}
 			}
-			_ = m.g.RemoveEndpoint(idx)
+			if idx == 0 {
+				return errResult("switch to another endpoint before removing the active endpoint")
+			}
+			removed := m.g.Settings.Endpoints[idx]
+			if err := m.g.RemoveEndpoint(idx); err != nil {
+				return errResult(err.Error())
+			}
+			if m.failedEndpoint != nil && sameEndpoint(*m.failedEndpoint, removed) {
+				m.clearEndpointFailure()
+				m.resetStack(m.rootMenu())
+				return menu.Result{}
+			}
 			return menu.Result{Replace: m.endpointsMenu()}
 		},
 	})
@@ -241,81 +303,121 @@ func (m *model) endpointsMenu() *menu.Menu {
 	}
 }
 
-// setupGuideMenu is shown when the preflight check fails. It diagnoses
-// the user's Tailscale status and provides actionable guidance.
+// setupGuideMenu is shown when endpoint activation or its /v1/models check
+// fails. A candidate endpoint remains configured, but the previous working
+// endpoint stays active until the candidate passes both stages.
 func (m *model) setupGuideMenu() *menu.Menu {
-	if ep := m.g.ActiveEndpoint(); ep.BridgeID != "" {
-		bridgeName := ep.BridgeID
-		if bridge, ok := m.g.Bridge(ep.BridgeID); ok {
-			bridgeName = bridge.Name
-		}
-		return &menu.Menu{
-			Title: setupGuideTitle,
-			Preamble: "Could not reach Aperture at " + ep.URL + " through bridge " + bridgeName + ".\n\n" +
-				"The bridge uses an embedded Tailscale node; this machine does not need Tailscale installed or running.",
-			Items: []menu.MenuItem{
-				{
-					Label: "Retry connection",
-					Action: func() menu.Result {
-						return menu.Result{Cmd: m.activateEndpointCmd(m.g.ActiveEndpoint())}
-					},
-				},
-				{
-					Label:  "Connection options",
-					Action: func() menu.Result { return menu.Result{Next: m.endpointsMenu()} },
-				},
-			},
-			Hint:   "Enter to select · Esc to quit",
-			OnBack: func() tea.Cmd { return m.quitCmd() },
-		}
+	target := m.g.ActiveEndpoint()
+	if m.failedEndpoint != nil {
+		target = *m.failedEndpoint
 	}
-
-	ts := checkTailscale()
 
 	var preamble string
-	switch ts {
-	case tsNotInstalled:
-		preamble = "Aperture connects to your AI providers through Tailscale.\n\nTailscale is not installed.\nInstall it from: https://tailscale.com/download"
-	case tsNotRunning:
-		preamble = "Aperture connects to your AI providers through Tailscale.\n\nTailscale is installed but not running.\nStart Tailscale, then retry."
-	case tsNotConnected:
-		preamble = "Aperture connects to your AI providers through Tailscale.\n\nTailscale is not connected to a network.\nLog in with: tailscale up"
-	case tsConnected:
-		preamble = "Tailscale is connected.\n\nCould not reach Aperture at " + m.g.ApertureHost + ".\nEither:\n  - set up an Aperture instance at https://aperture.tailscale.com/\n  - or enter a different Aperture URL below"
+	if target.BridgeID != "" {
+		bridgeName := target.BridgeID
+		if bridge, ok := m.g.Bridge(target.BridgeID); ok {
+			bridgeName = bridge.Name
+		}
+		preamble = "Could not reach Aperture at " + target.URL + " through bridge " + bridgeName + ".\n\n" +
+			"The bridge uses an embedded Tailscale node; this machine does not need Tailscale installed or running."
+	} else {
+		switch checkTailscale() {
+		case tsNotInstalled:
+			preamble = "Could not reach Aperture at " + target.URL + ".\n\nTailscale is not installed.\nInstall it from: https://tailscale.com/download"
+		case tsNotRunning:
+			preamble = "Could not reach Aperture at " + target.URL + ".\n\nTailscale is installed but not running.\nStart Tailscale, then retry."
+		case tsNotConnected:
+			preamble = "Could not reach Aperture at " + target.URL + ".\n\nTailscale is not connected to a network.\nLog in with: tailscale up"
+		case tsConnected:
+			preamble = "Tailscale is connected.\n\nCould not reach Aperture at " + target.URL + ".\nEither:\n  - set up an Aperture instance at https://aperture.tailscale.com/\n  - or enter a different Aperture URL below"
+		}
 	}
 
+	hasPrevious := m.connected && !sameEndpoint(target, m.g.ActiveEndpoint())
+	if hasPrevious {
+		preamble += "\n\nThe previous endpoint remains active: " + m.endpointLabel(m.g.ActiveEndpoint()) + "."
+	}
+
+	items := []menu.MenuItem{
+		{
+			Label: "Retry connection",
+			Action: func() menu.Result {
+				return menu.Result{Cmd: m.activateEndpointCmd(target)}
+			},
+		},
+		{
+			Label: "Edit endpoint URL",
+			Action: func() menu.Result {
+				m.promptForInput("Edit Endpoint:", "Current: "+target.URL, func(v string) tea.Cmd {
+					next, err := endpointFromInput(v, target.BridgeID)
+					if err != nil {
+						return simpleErrorCmd(err)
+					}
+					if err := m.g.ReplaceEndpoint(target, next); err != nil {
+						return simpleErrorCmd(err)
+					}
+					m.failedEndpoint = &next
+					return m.activateEndpointCmd(next)
+				})
+				return menu.Result{}
+			},
+		},
+		{
+			Label: "Connection options",
+			Action: func() menu.Result {
+				return menu.Result{Next: m.endpointsMenu()}
+			},
+		},
+	}
+	if hasPrevious {
+		items = append(items, menu.MenuItem{
+			Label: "Return to active endpoint",
+			Action: func() menu.Result {
+				m.clearEndpointFailure()
+				return menu.Result{Replace: m.rootMenu()}
+			},
+		})
+	}
+	if m.endpointConfigured(target) && !sameEndpoint(target, m.g.ActiveEndpoint()) {
+		items = append(items, menu.MenuItem{
+			Label: "Remove endpoint",
+			Action: func() menu.Result {
+				for i, ep := range m.g.Settings.Endpoints {
+					if !sameEndpoint(ep, target) {
+						continue
+					}
+					if err := m.g.RemoveEndpoint(i); err != nil {
+						return errResult(err.Error())
+					}
+					break
+				}
+				m.clearEndpointFailure()
+				return menu.Result{Replace: m.rootMenu()}
+			},
+		})
+	}
+
+	onBack := func() tea.Cmd { return m.quitCmd() }
+	if hasPrevious {
+		onBack = func() tea.Cmd {
+			m.clearEndpointFailure()
+			m.resetStack(m.rootMenu())
+			return tea.ClearScreen
+		}
+	}
 	return &menu.Menu{
 		Title:    setupGuideTitle,
 		Preamble: preamble,
-		Items: []menu.MenuItem{
-			{
-				Label: "Enter Aperture URL",
-				Action: func() menu.Result {
-					m.promptForInput("Aperture URL", "e.g. http://ai.example.com", func(v string) tea.Cmd {
-						v = strings.TrimSpace(v)
-						if !strings.Contains(v, "://") {
-							v = "http://" + v
-						}
-						_ = m.g.SetApertureHost(v)
-						return m.activateEndpointCmd(m.g.ActiveEndpoint())
-					})
-					return menu.Result{}
-				},
-			},
-			{
-				Label: "Retry connection",
-				Action: func() menu.Result {
-					return menu.Result{Cmd: m.activateEndpointCmd(m.g.ActiveEndpoint())}
-				},
-			},
-			{
-				Label:  "Connection options",
-				Action: func() menu.Result { return menu.Result{Next: m.endpointsMenu()} },
-			},
-		},
-		Hint:   "Enter to select · Esc to quit",
-		OnBack: func() tea.Cmd { return m.quitCmd() },
+		Items:    items,
+		Hint:     "Enter to select · Esc to go back",
+		OnBack:   onBack,
 	}
+}
+
+func (m *model) clearEndpointFailure() {
+	m.failedEndpoint = nil
+	m.preflightErr = ""
+	m.forcedToEndpoint = false
 }
 
 func (m *model) addEndpointConnectionMenu() *menu.Menu {
@@ -326,9 +428,14 @@ func (m *model) addEndpointConnectionMenu() *menu.Menu {
 				Label: "Direct",
 				Action: func() menu.Result {
 					m.promptForInput("Add Direct Endpoint:", "URL", func(v string) tea.Cmd {
-						_ = m.g.UpsertEndpoint(config.Endpoint{URL: strings.TrimSpace(v)})
-						m.refreshEndpointsMenu()
-						return nil
+						ep, err := endpointFromInput(v, "")
+						if err != nil {
+							return simpleErrorCmd(err)
+						}
+						if err := m.g.UpsertEndpoint(ep); err != nil {
+							return simpleErrorCmd(err)
+						}
+						return m.activateEndpointCmd(ep)
 					})
 					return menu.Result{}
 				},
@@ -343,52 +450,57 @@ func (m *model) addEndpointConnectionMenu() *menu.Menu {
 }
 
 func (m *model) endpointBridgeMenu() *menu.Menu {
+	items := make([]menu.MenuItem, 0, len(m.g.Settings.Bridges)+2)
 	if len(m.g.Settings.Bridges) == 0 {
-		return &menu.Menu{
-			Title: "Choose a bridge",
-			Items: []menu.MenuItem{
-				{
-					Label:    "No bridges configured.",
-					Disabled: true,
-				},
-				{
-					Label: "Add Bridge",
-					Action: func() menu.Result {
-						m.promptForInput("Add Bridge:", "Name", func(v string) tea.Cmd {
-							if _, err := m.g.AddBridge(v); err != nil {
-								return func() tea.Msg { return menu.SimpleDoneMsg{Err: err} }
-							}
-							m.refreshMenuByTitle("Choose a bridge", m.endpointBridgeMenu())
-							return nil
-						})
-						return menu.Result{}
-					},
-				},
-			},
-			Hint: "Enter to add a bridge · Esc to go back",
-		}
+		items = append(items, menu.MenuItem{
+			Label:    "No bridges configured.",
+			Disabled: true,
+		})
 	}
-	items := make([]menu.MenuItem, 0, len(m.g.Settings.Bridges))
 	for _, p := range m.g.Settings.Bridges {
 		p := p
 		items = append(items, menu.MenuItem{
 			Label:       p.Name,
 			Description: p.ID,
 			Action: func() menu.Result {
-				m.promptForInput("Add Bridge Endpoint:", "URL", func(v string) tea.Cmd {
-					_ = m.g.UpsertEndpoint(config.Endpoint{URL: strings.TrimSpace(v), BridgeID: p.ID})
-					m.refreshEndpointsMenu()
-					return nil
-				})
+				m.promptForBridgeEndpoint(p)
 				return menu.Result{}
 			},
 		})
 	}
+	items = append(items, menu.MenuItem{
+		Label: "Add Bridge",
+		Action: func() menu.Result {
+			m.promptForInput("Add Bridge:", "Name", func(v string) tea.Cmd {
+				bridge, err := m.g.AddBridge(v)
+				if err != nil {
+					return simpleErrorCmd(err)
+				}
+				m.refreshMenuByTitle("Choose a bridge", m.endpointBridgeMenu())
+				m.promptForBridgeEndpoint(bridge)
+				return nil
+			})
+			return menu.Result{}
+		},
+	})
 	return &menu.Menu{
 		Title: "Choose a bridge",
 		Items: items,
-		Hint:  "Enter to select · Esc to go back",
+		Hint:  "Enter to select or add · Esc to go back",
 	}
+}
+
+func (m *model) promptForBridgeEndpoint(bridge config.Bridge) {
+	m.promptForInput("Add Bridge Endpoint:", "URL", func(v string) tea.Cmd {
+		ep, err := endpointFromInput(v, bridge.ID)
+		if err != nil {
+			return simpleErrorCmd(err)
+		}
+		if err := m.g.UpsertEndpoint(ep); err != nil {
+			return simpleErrorCmd(err)
+		}
+		return m.activateEndpointCmd(ep)
+	})
 }
 
 func (m *model) endpointLabel(ep config.Endpoint) string {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -90,6 +90,8 @@ type model struct {
 	bridgeLogCtx     context.Context
 	bridgeLogs       []string
 	bridgeCancel     context.CancelFunc
+	failedEndpoint   *config.Endpoint
+	connected        bool
 }
 
 func (m *model) Init() tea.Cmd {
@@ -281,15 +283,20 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case preflightResult:
 		if msg.err != nil {
+			m.connected = false
 			m.preflightErr = msg.err.Error()
 			m.forcedToEndpoint = true
+			failed := m.g.ActiveEndpoint()
+			m.failedEndpoint = &failed
 			m.step = stepMenu
 			m.resetStack(m.setupGuideMenu())
 			return m, nil
 		}
 		m.g.Providers = msg.providers
+		m.connected = true
 		m.preflightErr = ""
 		m.forcedToEndpoint = false
+		m.failedEndpoint = nil
 		m.step = stepMenu
 		m.resetStack(m.rootMenu())
 		return m, tea.ClearScreen
@@ -297,17 +304,34 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case endpointActivationResult:
 		m.bridgeCancel = nil
 		if msg.err != nil {
+			if sameEndpoint(msg.endpoint, m.g.ActiveEndpoint()) {
+				m.connected = false
+			}
 			m.preflightErr = msg.err.Error()
 			m.forcedToEndpoint = true
-			m.g.ApertureHost = msg.endpoint.URL
+			failed := msg.endpoint
+			m.failedEndpoint = &failed
 			m.step = stepMenu
 			m.resetStack(m.setupGuideMenu())
 			return m, nil
 		}
+		if !sameEndpoint(m.g.ActiveEndpoint(), msg.endpoint) {
+			if err := m.g.SetActiveEndpoint(msg.endpoint); err != nil {
+				m.preflightErr = "could not save active endpoint: " + err.Error()
+				m.forcedToEndpoint = true
+				failed := msg.endpoint
+				m.failedEndpoint = &failed
+				m.step = stepMenu
+				m.resetStack(m.setupGuideMenu())
+				return m, nil
+			}
+		}
 		m.g.ApertureHost = msg.host
 		m.g.Providers = msg.providers
+		m.connected = true
 		m.preflightErr = ""
 		m.forcedToEndpoint = false
+		m.failedEndpoint = nil
 		m.step = stepMenu
 		m.resetStack(m.rootMenu())
 		return m, tea.ClearScreen
@@ -628,7 +652,7 @@ func (m *model) View() string {
 		return sb.String()
 	case stepError:
 		var sb strings.Builder
-		sb.WriteString(errorStyle.Render("Cannot launch"))
+		sb.WriteString(errorStyle.Render("Error"))
 		sb.WriteString("\n\n")
 		sb.WriteString(m.wrapText("", m.errMsg))
 		sb.WriteString("\n\n")
@@ -855,14 +879,18 @@ func assignTokens(items []menu.MenuItem) []string {
 // preflight-failure mode shows the red "couldn't reach" banner.
 func (m *model) menuHeader(top *menu.Menu) string {
 	if len(m.stack) == 1 && top.Title == rootTitle {
-		header := dotGreen + " Connected to " + m.g.ApertureHost
+		header := dotGreen + " Connected to " + m.endpointLabel(m.g.ActiveEndpoint())
 		if n := len(m.g.Providers); n > 0 {
 			header += fmt.Sprintf(" (%d providers)", n)
 		}
 		return m.wrapText("", header) + "\n\n"
 	}
 	if m.forcedToEndpoint && (top.Title == endpointsTitle || top.Title == setupGuideTitle) {
-		header := m.wrapText("", dotRed+" Could not reach "+m.g.ApertureHost) + "\n"
+		target := m.g.ActiveEndpoint()
+		if m.failedEndpoint != nil {
+			target = *m.failedEndpoint
+		}
+		header := m.wrapText("", dotRed+" Could not reach "+m.endpointLabel(target)) + "\n"
 		if m.preflightErr != "" {
 			header += dimStyle.Render(m.wrapText("  ", m.preflightErr)) + "\n"
 		}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -84,7 +85,11 @@ func TestRootMenu_QuickSelectPrepended(t *testing.T) {
 	withFakeClients(t, []clients.Client{fc})
 
 	m := &model{g: &config.Global{
-		LastLaunch: config.LaunchState{LastClientName: "A"},
+		Settings: config.Settings{Endpoints: []config.Endpoint{{URL: "http://ai"}}},
+		LastLaunch: config.LaunchState{
+			LastClientName:  "A",
+			LastEndpointURL: "http://ai",
+		},
 	}}
 	root := m.rootMenu()
 
@@ -119,13 +124,82 @@ func TestRootMenu_NoQuickSelectWhenReplayNil(t *testing.T) {
 	withFakeClients(t, []clients.Client{fc})
 
 	m := &model{g: &config.Global{
-		LastLaunch: config.LaunchState{LastClientName: "A"},
+		Settings: config.Settings{Endpoints: []config.Endpoint{{URL: "http://ai"}}},
+		LastLaunch: config.LaunchState{
+			LastClientName:  "A",
+			LastEndpointURL: "http://ai",
+		},
 	}}
 	root := m.rootMenu()
 	for _, it := range root.Items {
 		if !it.Hidden && strings.Contains(it.Label, "Quick select") {
 			t.Errorf("unexpected quick-select row: %+v", it)
 		}
+	}
+}
+
+func TestRootMenu_NoQuickSelectWithoutRecordedEndpoint(t *testing.T) {
+	fc := &fakeClient{
+		name:       "A",
+		installed:  true,
+		replayCmd:  func() tea.Msg { return menu.ExecDoneMsg{} },
+		quickLabel: "A via Whatever",
+	}
+	withFakeClients(t, []clients.Client{fc})
+
+	m := &model{g: &config.Global{
+		Settings:   config.Settings{Endpoints: []config.Endpoint{{URL: "http://ai"}}},
+		LastLaunch: config.LaunchState{LastClientName: "A"},
+	}}
+	for _, it := range m.rootMenu().Items {
+		if !it.Hidden && strings.Contains(it.Label, "Quick select") {
+			t.Errorf("unexpected quick-select row without a recorded endpoint: %+v", it)
+		}
+	}
+}
+
+func TestQuickSelectRequiresRecordedEndpointToBeActive(t *testing.T) {
+	replayed := false
+	fc := &fakeClient{
+		name:      "A",
+		installed: true,
+		replayCmd: func() tea.Msg {
+			replayed = true
+			return menu.ExecDoneMsg{}
+		},
+		quickLabel: "A via Whatever",
+	}
+	withFakeClients(t, []clients.Client{fc})
+
+	active := config.Endpoint{URL: "http://ai", BridgeID: "bridge-current"}
+	saved := config.Endpoint{URL: "http://ai", BridgeID: "bridge-saved"}
+	m := &model{
+		g: &config.Global{
+			Settings:  config.Settings{Endpoints: []config.Endpoint{active, saved}},
+			Providers: []config.ProviderInfo{{ID: "old-provider"}},
+			LastLaunch: config.LaunchState{
+				LastClientName:  "A",
+				LastEndpointURL: saved.URL,
+				LastBridgeID:    saved.BridgeID,
+			},
+		},
+	}
+	for _, item := range m.rootMenu().Items {
+		if !item.Hidden && strings.Contains(item.Label, "Quick select") {
+			t.Fatalf("quick-select shown for inactive endpoint: %+v", item)
+		}
+	}
+
+	// Switching back to the recorded URL and bridge makes the saved launch
+	// valid again without rewriting launch state.
+	m.g.Settings.Endpoints = []config.Endpoint{saved, active}
+	quick := m.rootMenu().Items[0]
+	if !strings.Contains(quick.Label, "Quick select") || quick.Action().Cmd == nil {
+		t.Fatalf("quick-select did not reappear for active recorded endpoint: %+v", quick)
+	}
+	quick.Action().Cmd()
+	if !replayed {
+		t.Fatal("quick-select did not replay saved launch")
 	}
 }
 
@@ -478,8 +552,118 @@ func TestEndpointBridgeMenu_AddsFirstBridgeInline(t *testing.T) {
 	if len(m.g.Settings.Bridges) != 1 || m.g.Settings.Bridges[0].Name != "Work Bridge" {
 		t.Fatalf("bridges = %+v", m.g.Settings.Bridges)
 	}
-	if top := m.top(); top.Title != "Choose a bridge" || len(top.Items) != 1 || top.Items[0].Label != "Work Bridge" {
+	if top := m.top(); top.Title != "Choose a bridge" || len(top.Items) != 2 || top.Items[0].Label != "Work Bridge" || top.Items[1].Label != "Add Bridge" {
 		t.Fatalf("bridge chooser was not refreshed: %+v", top)
+	}
+	if m.step != stepInput || m.inputTitle != "Add Bridge Endpoint:" {
+		t.Fatalf("adding bridge did not continue to endpoint URL: step=%v title=%q", m.step, m.inputTitle)
+	}
+}
+
+func TestEndpointBridgeMenu_OffersAddBridgeWhenOneExists(t *testing.T) {
+	m := &model{g: &config.Global{Settings: config.Settings{
+		Bridges: []config.Bridge{{ID: "bridge-abcdef", Name: "First"}},
+	}}}
+
+	var labels []string
+	for _, item := range m.endpointBridgeMenu().Items {
+		if !item.Disabled {
+			labels = append(labels, item.Label)
+		}
+	}
+	if got := strings.Join(labels, ","); got != "First,Add Bridge" {
+		t.Fatalf("bridge chooser labels = %q, want First,Add Bridge", got)
+	}
+}
+
+func TestBridgeEndpointFailureKeepsPreviousEndpointActive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp+"/.config")
+	old := config.Endpoint{URL: "http://old"}
+	bridge := config.Bridge{ID: "bridge-abcdef", Name: "Second"}
+	m := &model{
+		g: &config.Global{
+			ApertureHost: "http://old",
+			Settings: config.Settings{
+				Bridges:   []config.Bridge{bridge},
+				Endpoints: []config.Endpoint{old},
+			},
+			Providers: []config.ProviderInfo{{ID: "old-provider"}},
+		},
+		step:      stepMenu,
+		connected: true,
+	}
+	chooser := m.endpointBridgeMenu()
+	chooser.Items[0].Action()
+	want := config.Endpoint{URL: "http://new", BridgeID: bridge.ID}
+	cmd := m.inputOnSave(want.URL)
+	if cmd == nil {
+		t.Fatal("saving bridge endpoint did not begin activation")
+	}
+	if got := m.g.ActiveEndpoint(); !sameEndpoint(got, old) {
+		t.Fatalf("active endpoint changed before activation: %+v", got)
+	}
+	if !m.endpointConfigured(want) {
+		t.Fatalf("candidate endpoint was not saved: %+v", m.g.Settings.Endpoints)
+	}
+
+	msg := cmd()
+	result, ok := msg.(endpointActivationResult)
+	if !ok {
+		t.Fatalf("activation message = %T", msg)
+	}
+	if !sameEndpoint(result.endpoint, want) || result.err == nil {
+		t.Fatalf("activation result = %+v, want failed second bridge endpoint", result)
+	}
+	m.Update(result)
+	if got := m.g.ActiveEndpoint(); !sameEndpoint(got, old) {
+		t.Fatalf("failed activation changed active endpoint: %+v", got)
+	}
+	if m.g.ApertureHost != "http://old" || len(m.g.Providers) != 1 || m.g.Providers[0].ID != "old-provider" {
+		t.Fatalf("failed activation replaced working runtime state: host=%q providers=%+v", m.g.ApertureHost, m.g.Providers)
+	}
+	if !strings.Contains(m.top().Preamble, "previous endpoint remains active") {
+		t.Fatalf("failure menu does not explain retained endpoint: %q", m.top().Preamble)
+	}
+	var actions []string
+	for _, item := range m.top().Items {
+		actions = append(actions, item.Label)
+	}
+	for _, want := range []string{"Retry connection", "Edit endpoint URL", "Connection options", "Return to active endpoint", "Remove endpoint"} {
+		if !slices.Contains(actions, want) {
+			t.Errorf("failure actions = %v, missing %q", actions, want)
+		}
+	}
+}
+
+func TestDirectEndpointIsPromotedOnlyAfterModelsSucceed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp+"/.config")
+	srv := modelsServer(t)
+	old := config.Endpoint{URL: "http://old"}
+	m := &model{
+		g: &config.Global{
+			ApertureHost: "http://old",
+			Settings:     config.Settings{Endpoints: []config.Endpoint{old}},
+			Providers:    []config.ProviderInfo{{ID: "old-provider"}},
+		},
+		step: stepMenu,
+	}
+
+	m.addEndpointConnectionMenu().Items[0].Action()
+	cmd := m.inputOnSave(srv.URL)
+	if got := m.g.ActiveEndpoint(); !sameEndpoint(got, old) {
+		t.Fatalf("active endpoint changed before /v1/models: %+v", got)
+	}
+	activation := cmd()
+	m.Update(activation)
+	if got := m.g.ActiveEndpoint(); got.URL != srv.URL {
+		t.Fatalf("active endpoint = %+v, want %q", got, srv.URL)
+	}
+	if m.g.ApertureHost != srv.URL || len(m.g.Providers) != 1 || m.g.Providers[0].ID != "anthropic" {
+		t.Fatalf("successful activation state: host=%q providers=%+v", m.g.ApertureHost, m.g.Providers)
 	}
 }
 
@@ -545,7 +729,7 @@ func TestFetchProvidersIncludesErrorResponseBody(t *testing.T) {
 }
 
 func TestFetchProvidersUsesModelsEndpoint(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := modelsServerWithHandler(t, func(r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q, want GET", r.Method)
 		}
@@ -554,6 +738,29 @@ func TestFetchProvidersUsesModelsEndpoint(t *testing.T) {
 		}
 		if got := r.Header.Get("User-Agent"); got != "aperture-cli" {
 			t.Errorf("User-Agent = %q, want aperture-cli", got)
+		}
+	})
+	defer srv.Close()
+
+	got, err := fetchProviders(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "anthropic" || !got[0].SupportsEndpoint(config.EndpointAnthropicMessages) {
+		t.Fatalf("fetchProviders() = %#v, want Anthropic Messages provider", got)
+	}
+}
+
+func modelsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return modelsServerWithHandler(t, nil)
+}
+
+func modelsServerWithHandler(t *testing.T, check func(*http.Request)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if check != nil {
+			check(r)
 		}
 		_, _ = w.Write([]byte(`{
 			"object":"list",
@@ -567,15 +774,8 @@ func TestFetchProvidersUsesModelsEndpoint(t *testing.T) {
 			}]
 		}`))
 	}))
-	defer srv.Close()
-
-	got, err := fetchProviders(srv.URL + "/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != "anthropic" || !got[0].SupportsEndpoint(config.EndpointAnthropicMessages) {
-		t.Fatalf("fetchProviders() = %#v, want Anthropic Messages provider", got)
-	}
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 func TestWrapTextPreservesContentWithinTerminalWidth(t *testing.T) {
@@ -632,5 +832,24 @@ func TestEndpointLabel_ShowsBridge(t *testing.T) {
 	got := m.endpointLabel(config.Endpoint{URL: "http://ai", BridgeID: "bridge-abcdef"})
 	if got != "http://ai via Work" {
 		t.Errorf("endpointLabel = %q", got)
+	}
+}
+
+func TestRootHeaderShowsLogicalBridgeEndpoint(t *testing.T) {
+	m := &model{
+		g: &config.Global{
+			ApertureHost: "http://127.0.0.1:41234",
+			Settings: config.Settings{
+				Bridges:   []config.Bridge{{ID: "bridge-abcdef", Name: "Work"}},
+				Endpoints: []config.Endpoint{{URL: "http://ai", BridgeID: "bridge-abcdef"}},
+			},
+		},
+		step:      stepMenu,
+		connected: true,
+	}
+	m.resetStack(m.rootMenu())
+	header := m.menuHeader(m.top())
+	if !strings.Contains(header, "http://ai via Work") || strings.Contains(header, "127.0.0.1") {
+		t.Fatalf("root header = %q", header)
 	}
 }


### PR DESCRIPTION
Make bridge endpoint setup a single flow. The bridge chooser now always offers Add Bridge, and creating or selecting a bridge proceeds directly to the endpoint URL, authentication, and model discovery.

Treat added or selected endpoints as candidates until /v1/models succeeds. A failed candidate stays configured for retry or editing while the previous working endpoint and provider catalog remain active. The failure screen offers retry, edit, connection options, return, and removal actions, and the connected banner shows the logical endpoint and bridge instead of the localhost proxy.

Record the endpoint URL and bridge ID with launcher state, and only show quick select when that exact endpoint is active. This prevents a replay from silently switching Aperture instances or bridge identities; switching back makes the saved replay available again.

Persist configuration mutations before updating in-memory state and cover the endpoint, bridge, failure, banner, and replay behavior with focused tests.